### PR TITLE
Start router programs with working directory

### DIFF
--- a/VRCOSC.Game/Managers/StartupManager.cs
+++ b/VRCOSC.Game/Managers/StartupManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) VolcanicArts. Licensed under the GPL-3.0 License.
+// Copyright (c) VolcanicArts. Licensed under the GPL-3.0 License.
 // See the LICENSE file in the repository root for full license text.
 
 using System;
@@ -71,7 +71,10 @@ public class StartupManager
 
                 if (Process.GetProcessesByName(processName).Any()) return;
 
-                Process.Start(new ProcessStartInfo(instance.FilePath.Value, instance.LaunchArguments.Value));
+                Process.Start(new ProcessStartInfo(instance.FilePath.Value, instance.LaunchArguments.Value)
+                {
+                    WorkingDirectory = Path.GetDirectoryName(instance.FilePath.Value)
+                });
                 logger.Log($"Running file {instance.FilePath.Value}" + (string.IsNullOrEmpty(instance.LaunchArguments.Value) ? string.Empty : $" with launch arguments {instance.LaunchArguments.Value}"));
             }
             catch (Exception e)


### PR DESCRIPTION
Programs when launched had VRCOSC's working directory. OSCLeash (as an example) will fail because of that. This PR supplies working directory based on their location.