### PR TITLE
Add new OpenVR controller bindings and update manifest

### DIFF
--- a/VRCOSC.App/Resources/OpenVR/action_manifest.json
+++ b/VRCOSC.App/Resources/OpenVR/action_manifest.json
@@ -84,8 +84,20 @@
 			"binding_url": "oculus_touch_bindings.json"
 		},
 		{
-			"controller_type": "vive",
+			"controller_type": "vive_controller",
 			"binding_url": "vive_bindings.json"
+		},
+		{
+			"controller_type": "vd_hand_controller",
+			"binding_url": "vd_hand_controller_bindings.json"
+		},
+		{
+			"controller_type": "holographic_controller",
+			"binding_url": "holographic_controller_bindings.json"
+		},
+		{
+			"controller_type": "vive_cosmos_controller",
+			"binding_url": "vive_cosmos_controller_bindings.json"
 		}
 	]
 }

--- a/VRCOSC.App/Resources/OpenVR/holographic_controller_bindings.json
+++ b/VRCOSC.App/Resources/OpenVR/holographic_controller_bindings.json
@@ -1,0 +1,148 @@
+{
+	"alias_info": {},
+	"app_key": "volcanicarts.vrcosc",
+	"bindings": {
+		"/actions/haptic": {
+			"haptics": [
+				{
+					"output": "/actions/haptic/out/lefthand",
+					"path": "/user/hand/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/righthand",
+					"path": "/user/hand/right/output/haptic"
+				}
+			]
+		},
+		"/actions/main": {
+			"sources": [
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/left_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/left_stick_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/left_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/left_grip_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_primary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_primary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/application_menu"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/main/in/left_pad_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_pad_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_pad_click"
+						}
+					},
+					"mode": "trackpad",
+					"path": "/user/hand/left/input/trackpad"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/right_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/right_stick_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/right_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/right_grip_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/grip"
+				},
+				{
+					"inputs": {
+						"position": {
+							"output": "/actions/main/in/right_pad_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_pad_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_pad_click"
+						}
+					},
+					"mode": "trackpad",
+					"path": "/user/hand/right/input/trackpad"
+				}
+			]
+		}
+	},
+	"controller_type": "holographic_controller",
+	"description": "Windows Mixed Reality Bindings for VRCOSC",
+	"name": "vrcosc_holographic_controller",
+	"options": {},
+	"simulated_actions": []
+}
+

--- a/VRCOSC.App/Resources/OpenVR/oculus_touch_bindings.json
+++ b/VRCOSC.App/Resources/OpenVR/oculus_touch_bindings.json
@@ -65,7 +65,16 @@
 						}
 					},
 					"mode": "joystick",
-					"path": "/user/hand/left/input/thumbstick"
+					"path": "/user/hand/left/input/joystick"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/joystick"
 				},
 				{
 					"inputs": {
@@ -146,7 +155,16 @@
 						}
 					},
 					"mode": "joystick",
-					"path": "/user/hand/right/input/thumbstick"
+					"path": "/user/hand/right/input/joystick"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/right_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
 				},
 				{
 					"inputs": {

--- a/VRCOSC.App/Resources/OpenVR/vd_hand_controller_bindings.json
+++ b/VRCOSC.App/Resources/OpenVR/vd_hand_controller_bindings.json
@@ -1,0 +1,190 @@
+{
+	"alias_info": {},
+	"app_key": "volcanicarts.vrcosc",
+	"bindings": {
+		"/actions/haptic": {
+			"haptics": [
+				{
+					"output": "/actions/haptic/out/lefthand",
+					"path": "/user/hand/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/righthand",
+					"path": "/user/hand/right/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/leftfoot",
+					"path": "/user/foot/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/rightfoot",
+					"path": "/user/foot/right/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/waist",
+					"path": "/user/waist/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/chest",
+					"path": "/user/chest/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/leftknee",
+					"path": "/user/knee/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/rightknee",
+					"path": "/user/knee/right/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/leftelbow",
+					"path": "/user/elbow/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/rightelbow",
+					"path": "/user/elbow/right/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/head",
+					"path": "/user/head/output/haptic"
+				}
+			]
+		},
+		"/actions/main": {
+			"sources": [
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/left_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/left_stick_position"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/left_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_primary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_primary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/x"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_secondary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_secondary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/y"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/left_grip_pull"
+						},
+						"click": {
+							"output": "/actions/main/in/left_grip_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/right_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/right_stick_position"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/right_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/right_primary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_primary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/a"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/right_secondary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_secondary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/b"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/right_grip_pull"
+						},
+						"click": {
+							"output": "/actions/main/in/right_grip_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/grip"
+				}
+			]
+		}
+	},
+	"controller_type": "vd_hand_controller",
+	"description": "Virtual Desktop Bindings for VRCOSC",
+	"name": "vrcosc_vd_hand_controller",
+	"options": {},
+	"simulated_actions": []
+}
+

--- a/VRCOSC.App/Resources/OpenVR/vive_cosmos_controller_bindings.json
+++ b/VRCOSC.App/Resources/OpenVR/vive_cosmos_controller_bindings.json
@@ -1,0 +1,160 @@
+{
+	"alias_info": {},
+	"app_key": "volcanicarts.vrcosc",
+	"bindings": {
+		"/actions/haptic": {
+			"haptics": [
+				{
+					"output": "/actions/haptic/out/lefthand",
+					"path": "/user/hand/left/output/haptic"
+				},
+				{
+					"output": "/actions/haptic/out/righthand",
+					"path": "/user/hand/right/output/haptic"
+				}
+			]
+		},
+		"/actions/main": {
+			"sources": [
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/left_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/left_stick_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/left/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/left_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/left_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/trigger"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/left_grip_pull"
+						},
+						"click": {
+							"output": "/actions/main/in/left_grip_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/left/input/grip"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_primary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_primary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/x"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/left_secondary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/left_secondary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/left/input/y"
+				},
+				{
+					"inputs": {
+						"click": {
+							"output": "/actions/main/in/right_stick_click"
+						},
+						"position": {
+							"output": "/actions/main/in/right_stick_position"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_stick_touch"
+						}
+					},
+					"mode": "joystick",
+					"path": "/user/hand/right/input/joystick"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/right_trigger_pull"
+						},
+						"touch": {
+							"output": "/actions/main/in/right_trigger_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_trigger_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/trigger"
+				},
+				{
+					"inputs": {
+						"pull": {
+							"output": "/actions/main/in/right_grip_pull"
+						},
+						"click": {
+							"output": "/actions/main/in/right_grip_click"
+						}
+					},
+					"mode": "trigger",
+					"path": "/user/hand/right/input/grip"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/right_primary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_primary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/a"
+				},
+				{
+					"inputs": {
+						"touch": {
+							"output": "/actions/main/in/right_secondary_touch"
+						},
+						"click": {
+							"output": "/actions/main/in/right_secondary_click"
+						}
+					},
+					"mode": "button",
+					"path": "/user/hand/right/input/b"
+				}
+			]
+		}
+	},
+	"controller_type": "vive_cosmos_controller",
+	"description": "Vive Cosmos Bindings for VRCOSC",
+	"name": "vrcosc_vive_cosmos_controller",
+	"options": {},
+	"simulated_actions": []
+}
+


### PR DESCRIPTION
Added bindings for Holographic, Virtual Desktop Hand, and Vive Cosmos controllers. Updated action_manifest.json to register new controller types and fixed the controller_type for Vive. Improved oculus_touch_bindings.json to support stick touch input and standardized joystick paths.